### PR TITLE
Terraform + AWS - Static Site With S3 & CloudFront Example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,5 @@ override.tf.json
 # Ignore CLI configuration files
 .terraformrc
 terraform.rc
+
+.DS_Store

--- a/aws/static-site/.terraform.lock.hcl
+++ b/aws/static-site/.terraform.lock.hcl
@@ -1,0 +1,24 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version = "4.65.0"
+  hashes = [
+    "h1:npDM2DHnGDKlXJJGWdBpTVywKHa9clSgXzvin5phSM4=",
+    "zh:0461b8dfc14e94971bfd12783cbd5a5574b9fcfc3694b6afaa8836f90b61c1f9",
+    "zh:24a27e7b1f6eb33e9da6f2ffaaa6bc48e933a24224c6572d6e588994e5c7130b",
+    "zh:2ca189d04573414bef4876c17ccb2b76f6e721e0450f6ab3700d94d7c04bec64",
+    "zh:3fb0654a527677231dab2140e9a55df3b90dba478b3db50001e21a045437a47a",
+    "zh:4918173d9c7d2735908622c17efd01746a046f0a571690afa7dd0866f22045f7",
+    "zh:491d259b15166f751076d2bdc443928ca63f6c0a83b02ea75fff8b4224662207",
+    "zh:4ff8e178f0656f04f88558c295a1d246b1bdcf5ad81d8b3b9ccceaeca2eb7fa8",
+    "zh:5e4eaf2855a740124f4bbe34ac4bd22c7f320aa3e91d9cef64396ad0a1571544",
+    "zh:65762c60c4bac2e0d55ed8c2877e455e84465cb12f0c885363a1b561cd4f5f07",
+    "zh:7c5e4f85eb5f70e6da2d64701dd5551f2bc334dbb9add76bfc6a2bea6acf4483",
+    "zh:90d32b238113528319d7a5fade97bd8ac9a8b654482fc9056478a43d2e297886",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:e6ed3299516a8fb2292af7e7e123d09817dfd8e039aaf35ad5a276f739668e88",
+    "zh:eb84fa96c63d836b3b4689835cb7c4487808dfd1ba7ddacf4d8c4c6ff65cdbef",
+    "zh:ff97d1498193c99c9c35afd9bfcdce011abf460ec041721727d6e542f7a3bedd",
+  ]
+}

--- a/aws/static-site/README.md
+++ b/aws/static-site/README.md
@@ -8,6 +8,11 @@ This Terraform AWS code samples demonstrates how to configure and deploy a stati
 
 When working with static sites, it's more efficient to host the assets in an S3 Bucket, rather than a server or container that is always running. To achieve this, we store the assets in an S3 Bucket, and create a CloudFront Distribution that uses the S3 Bucket as its origin to retrieve, serve, and cache content.
 
+## Requirements
+
+- [Terraform v1.4.6](https://developer.hashicorp.com/terraform/downloads)
+- AWS Account
+
 ## AWS Services Utilized
 
 - CloudFront
@@ -30,6 +35,7 @@ After successful deployment, Terraform will output:
 - CloudFront Distribution Endpoint
 
 ## Testing
+
 - To test that the static site is running, we can use either the CloudFront Distribution endpoint.
 - The static site contains two files: `/index.html` and `/error.html`.
-    - `/index.html` is served whenever you visit the root path or `/index.html`.
+  - `/index.html` is served whenever you visit the root path or `/index.html`.

--- a/aws/static-site/README.md
+++ b/aws/static-site/README.md
@@ -2,11 +2,11 @@
 
 ## Overview
 
-This Terraform AWS code samples demonstrates how to configure and deploy a static site using S3 and CloudFront.
+This Terraform AWS code sample demonstrates how to configure and deploy a static site using Simple Storage Service (S3) and CloudFront.
 
 ## Real-world Example
 
-When working with static sites, it's more efficient to host the assets in an S3 Bucket, rather than a server or container that is always running. To achieve this, we store the assets in an S3 Bucket, and create a CloudFront Distribution that uses the S3 Bucket as its origin to retrieve, serve, and cache content.
+When working with static sites, it's more efficient to host the assets in S3 buckets, rather than a server or container that's always running. To achieve this, we store the assets in an S3 bucket, and create a CloudFront Distribution that uses the S3 bucket as its origin to retrieve, serve, and cache content.
 
 ## Requirements
 

--- a/aws/static-site/README.md
+++ b/aws/static-site/README.md
@@ -1,0 +1,35 @@
+# Terraform AWS Static Site
+
+## Overview
+
+This Terraform AWS code samples demonstrates how to configure and deploy a static site using S3 and CloudFront.
+
+## Real-world Example
+
+When working with static sites, it's more efficient to host the assets in an S3 Bucket, rather than a server or container that is always running. To achieve this, we store the assets in an S3 Bucket, and create a CloudFront Distribution that uses the S3 Bucket as its origin to retrieve, serve, and cache content.
+
+## AWS Services Utilized
+
+- CloudFront
+- S3
+
+## Deploying
+
+- Authenticate to an AWS account via a Command Line Interface (CLI).
+- Navigate to this `aws/static-site` directory.
+- In the `backend.tf` file, change the bucket name to something unique. This S3 bucket will contain the [remote Terraform state](https://developer.hashicorp.com/terraform/language/settings/backends/s3). Otherwise for local state, comment the contents of `backend.tf` out.
+- `terraform init` to initialize and prepare the Terraform directory.
+- `terraform validate` to check if the Terraform configuration is valid.
+- `terraform plan` to preview the actions that Terraform will perform.
+- `terraform apply` deploys (create/update/destroy) the infrastructure.
+
+## Outputs
+
+After successful deployment, Terraform will output:
+
+- CloudFront Distribution Endpoint
+
+## Testing
+- To test that the static site is running, we can use either the CloudFront Distribution endpoint.
+- The static site contains two files: `/index.html` and `/error.html`.
+    - `/index.html` is served whenever you visit the root path or `/index.html`.

--- a/aws/static-site/README.md
+++ b/aws/static-site/README.md
@@ -22,7 +22,14 @@ When working with static sites, it's more efficient to host the assets in an S3 
 
 - Authenticate to an AWS account via a Command Line Interface (CLI).
 - Navigate to this `aws/static-site` directory.
-- In the `backend.tf` file, change the bucket name to something unique. This S3 bucket will contain the [remote Terraform state](https://developer.hashicorp.com/terraform/language/settings/backends/s3). Otherwise for local state, comment the contents of `backend.tf` out.
+- Do you want to use [Terraform Remote State](https://developer.hashicorp.com/terraform/language/state/remote)?
+  - YES
+    - [Create a new S3 bucket](https://docs.aws.amazon.com/AmazonS3/latest/userguide/create-bucket-overview.html) using the AWS CLI or console:
+      - CLI: `aws s3 mb s3://unique-bucket-name-tf-state`
+      - Console: AWS &#8594; S3 &#8594; `Create bucket` &#8594; Fill in required fields &#8594; `Create bucket`
+    - In the `backend.tf` file, update the bucket name to the bucket you created. This S3 bucket will contain the [remote Terraform state](https://developer.hashicorp.com/terraform/language/settings/backends/s3).
+  - NO 
+    - Comment the contents of `backend.tf` out and proceed
 - `terraform init` to initialize and prepare the Terraform directory.
 - `terraform validate` to check if the Terraform configuration is valid.
 - `terraform plan` to preview the actions that Terraform will perform.

--- a/aws/static-site/backend.tf
+++ b/aws/static-site/backend.tf
@@ -1,4 +1,7 @@
 terraform {
+  # Terraform Remote State Configurations
+  # https://developer.hashicorp.com/terraform/language/state/remote
+  # https://developer.hashicorp.com/terraform/language/settings/backends/s3
   backend "s3" {
     # Change this remote state bucket name before deploying
     bucket = "tf-examples-state"

--- a/aws/static-site/backend.tf
+++ b/aws/static-site/backend.tf
@@ -1,0 +1,10 @@
+terraform {
+  backend "s3" {
+    # Change this remote state bucket name before deploying
+    bucket = "tf-examples-state"
+
+    key     = "aws/static-site/terraform.tfstate"
+    region  = "us-east-1"
+    encrypt = true
+  }
+}

--- a/aws/static-site/data.tf
+++ b/aws/static-site/data.tf
@@ -1,1 +1,2 @@
-data "aws_caller_identity" "aws_account" {}
+# Makes caller information accessible
+data "aws_caller_identity" "current" {}

--- a/aws/static-site/data.tf
+++ b/aws/static-site/data.tf
@@ -1,0 +1,1 @@
+data "aws_caller_identity" "aws_account" {}

--- a/aws/static-site/main.tf
+++ b/aws/static-site/main.tf
@@ -1,6 +1,6 @@
 # Assigns local values for use
 locals {
-  account_id = data.aws_caller_identity.aws_account.account_id
+  account_id = data.aws_caller_identity.current.account_id
   content_types = {
     ".html" = "text/html",
     ".css"  = "text/css",

--- a/aws/static-site/main.tf
+++ b/aws/static-site/main.tf
@@ -1,0 +1,111 @@
+# Assigns local values for use
+locals {
+  account_id = data.aws_caller_identity.aws_account.account_id
+  content_types = {
+    ".html" = "text/html",
+    ".css"  = "text/css",
+    ".js"   = "text/javascript"
+  }
+}
+
+# Creates S3 bucket to store static site files
+resource "aws_s3_bucket" "content_bucket" {}
+
+# Creates am S3 bucket policy for content_bucket
+resource "aws_s3_bucket_policy" "content_bucket_policy" {
+  bucket = aws_s3_bucket.content_bucket.id
+  policy = jsonencode({
+    "Version" : "2012-10-17",
+    "Statement" : {
+      "Sid" : "AllowCloudFrontServicePrincipalReadOnly",
+      "Effect" : "Allow",
+      "Principal" : {
+        "Service" : "cloudfront.amazonaws.com"
+      },
+      "Action" : "s3:GetObject",
+      "Resource" : "arn:aws:s3:::${aws_s3_bucket.content_bucket.id}/*",
+      "Condition" : {
+        "StringEquals" : {
+          "AWS:SourceArn" : "arn:aws:cloudfront::${local.account_id}:distribution/${aws_cloudfront_distribution.cloudfront.id}"
+        }
+      }
+    }
+  })
+  depends_on = [aws_cloudfront_distribution.cloudfront]
+}
+
+# Enables versioning for the S3 bucket content_bucket
+resource "aws_s3_bucket_versioning" "content_bucket_versioning" {
+  bucket = aws_s3_bucket.content_bucket.id
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+# Copies the static files from site-assets to the S3 bucket
+resource "aws_s3_object" "object" {
+  for_each = fileset("site-assets", "**/*")
+
+  bucket      = aws_s3_bucket.content_bucket.id
+  key         = each.key
+  source      = "site-assets/${each.value}"
+  source_hash = filemd5("site-assets/${each.value}")
+
+  # Updates the content type of the files accordingly
+  content_type = lookup(
+    local.content_types,
+    regex("\\.[^.]+$", each.value),
+    null
+  )
+}
+
+# Creates a CloudFront Origin Access Control to access the static content S3 bucket
+resource "aws_cloudfront_origin_access_control" "cloudfront_oac" {
+  name                              = "cloudfront_oac"
+  origin_access_control_origin_type = "s3"
+  signing_behavior                  = "always"
+  signing_protocol                  = "sigv4"
+}
+
+# Creates a new CloudFront Distribution
+resource "aws_cloudfront_distribution" "cloudfront" {
+  enabled             = true
+  is_ipv6_enabled     = true
+  default_root_object = "index.html"
+
+  origin {
+    domain_name              = aws_s3_bucket.content_bucket.bucket_domain_name
+    origin_access_control_id = aws_cloudfront_origin_access_control.cloudfront_oac.id
+    origin_id                = "s3_origin"
+  }
+
+  default_cache_behavior {
+    allowed_methods        = ["GET", "HEAD"]
+    cached_methods         = ["GET", "HEAD"]
+    compress               = true
+    default_ttl            = 3600
+    max_ttl                = 86400
+    min_ttl                = 0
+    target_origin_id       = "s3_origin"
+    viewer_protocol_policy = "allow-all"
+
+    forwarded_values {
+      query_string = false
+
+      cookies {
+        forward = "none"
+      }
+    }
+  }
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+      locations        = []
+    }
+  }
+
+  viewer_certificate {
+    cloudfront_default_certificate = true
+  }
+}

--- a/aws/static-site/outputs.tf
+++ b/aws/static-site/outputs.tf
@@ -1,3 +1,4 @@
+# Outputs CloudFront public endpoint
 output "cloudfront_endpoint" {
   value = "https://${aws_cloudfront_distribution.cloudfront.domain_name}"
 }

--- a/aws/static-site/outputs.tf
+++ b/aws/static-site/outputs.tf
@@ -1,0 +1,3 @@
+output "cloudfront_endpoint" {
+  value = "https://${aws_cloudfront_distribution.cloudfront.domain_name}"
+}

--- a/aws/static-site/providers.tf
+++ b/aws/static-site/providers.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "4.65.0"
+    }
+  }
+}
+
+provider "aws" {
+  region                      = var.region
+  skip_credentials_validation = true
+  skip_requesting_account_id  = true
+}

--- a/aws/static-site/providers.tf
+++ b/aws/static-site/providers.tf
@@ -9,6 +9,8 @@ terraform {
 
 provider "aws" {
   region                      = var.region
+  
+  # Allows terraform plan to run without being authenticated to the AWS CLI
   skip_credentials_validation = true
   skip_requesting_account_id  = true
 }

--- a/aws/static-site/site-assets/error.html
+++ b/aws/static-site/site-assets/error.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="stylesheet" href="styles.css" />
+    <title>Error</title>
+  </head>
+  <body id="error">
+    <h1>Sorry, that page doesn't exist...</h1>
+  </body>
+</html>

--- a/aws/static-site/site-assets/index.html
+++ b/aws/static-site/site-assets/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="stylesheet" href="styles.css" />
+    <title>Homepage</title>
+  </head>
+  <body id="success">
+    <h1>Welcome to Your New Static Site!</h1>
+  </body>
+</html>

--- a/aws/static-site/site-assets/styles.css
+++ b/aws/static-site/site-assets/styles.css
@@ -1,0 +1,13 @@
+body {
+  color: whitesmoke;
+  text-align: center;
+  font-family: "Gill Sans", "Gill Sans MT", Calibri, "Trebuchet MS", sans-serif;
+}
+
+#success {
+  background-color: rgb(0, 128, 0, 0.5);
+}
+
+#error {
+  background-color: rgb(255, 0, 0, 0.5);
+}

--- a/aws/static-site/variables.tf
+++ b/aws/static-site/variables.tf
@@ -1,0 +1,4 @@
+variable "region" {
+  description = "The AWS region to deploy into"
+  default     = "us-east-1"
+}


### PR DESCRIPTION
- Adds Terraform code to configure and deploy an AWS static site with S3 and CloudFront
- Adds a detailed README with deployment and testing instructions.